### PR TITLE
Updated Spotify to return duration in seconds

### DIFF
--- a/Sources/Player/Spotify/Spotify.swift
+++ b/Sources/Player/Spotify/Spotify.swift
@@ -97,6 +97,6 @@ extension SpotifyTrack {
         if let spotifyUrl = spotifyUrl {
             url = URL(fileURLWithPath: spotifyUrl)
         }
-        return MusicTrack(id: id, title: title, album: album, artist: artist, duration: TimeInterval(duration), artwork: artwork, lyrics: nil, url: url, originalTrack: self as? SBObject)
+        return MusicTrack(id: id, title: title, album: album, artist: artist, duration: TimeInterval(duration/1000), artwork: artwork, lyrics: nil, url: url, originalTrack: self as? SBObject)
     }
 }


### PR DESCRIPTION
Spotify returned duration in millisecs, while iTunes returned the duration in seconds. I suggest that players should return the duration data in the same unit. I'm not sure how vox returns the data. (i dont use vox). If vox returns millisecs as well then I suggest to change iTunes to millisecs.